### PR TITLE
feat: Highlight dashboard row on save

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -172,6 +172,7 @@
 
         .low-stock { background-color: #FFF0F0; }
         .negative-stock { background-color: #FFDADA; font-weight: bold; }
+        .row-saved { background-color: #E6FFED !important; } /* Green for saved rows */
         .error-row { background-color: #ffe5e5 !important; }
         .error-row:hover { background-color: #ffdddd !important; }
         .badge { padding:2px 6px; border-radius:10px; font-size:12px; }
@@ -524,9 +525,15 @@
                 .withSuccessHandler(response => {
                     setLoadingState(false);
                     if (response.success && response.updatedProducts) {
-                        // Update local state from the response for data consistency,
-                        // even though we are not re-rendering immediately.
+                        // Update local state and apply visual feedback.
                         response.updatedProducts.forEach(updatedProd => {
+                            // Find the table row and apply the saved style.
+                            const row = document.querySelector(`tr[data-product-base="${updatedProd.productBase}"]`);
+                            if (row) {
+                                row.classList.add('row-saved');
+                            }
+
+                            // Update local state for data consistency.
                             if (updatedProd.state) {
                                 estadosMap[updatedProd.productBase] = updatedProd.state;
                             }


### PR DESCRIPTION
Adds a visual indicator to the inventory dashboard. When a 'Stock Real' value is successfully saved, the corresponding product row will now turn green.

- A new CSS class `.row-saved` has been added to `dashboard.html` to style the saved rows.
- The `handleItemSave` JavaScript function has been updated to apply this class to the appropriate row upon receiving a successful response from the server.